### PR TITLE
Fix namespace

### DIFF
--- a/src/Stuart/Converters/JsonToJob.php
+++ b/src/Stuart/Converters/JsonToJob.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Stuart\converters;
+namespace Stuart\Converters;
 
 use Stuart\Job;
 


### PR DESCRIPTION
The case typo in the namespace is causing some warnings with autoloading.