### PR TITLE
Allow Guzzle client override

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ $authenticator = new \Stuart\Infrastructure\Authenticator($environment, $api_cli
 $client = new \Stuart\Client($authenticator);
 ```
 
+You can also pass your own Guzzle client instance to the `\Stuart\Client` constructor:
+
+```php
+$guzzleClient = new \Guzzle\Client();
+$client = new \Stuart\Client($authenticator, $guzzleClient);
+```
+
+This can be useful if you need to attach middlewares to the Guzzle client used by the Stuart client.
+
 ### Create a Job
 **Important**: Even if you can create a Job with a minimal set of parameters, we **highly recommend** that you fill as many information as 
 you can in order to ensure the delivery process goes well.

--- a/src/Stuart/Client.php
+++ b/src/Stuart/Client.php
@@ -11,9 +11,9 @@ class Client
     private $jobRepository;
     private $jobPricingRepository;
 
-    public function __construct($authenticator)
+    public function __construct($authenticator, \GuzzleHttp\Client $client = null)
     {
-        $guzzleClient = new \GuzzleHttp\Client();
+        $guzzleClient = $client ?: new \GuzzleHttp\Client();
         $httpClient = new HttpClient($authenticator, $guzzleClient);
         $this->jobRepository = new JobRepository($httpClient);
         $this->jobPricingRepository = new JobPricingRepository($httpClient);


### PR DESCRIPTION
This change allows library users to provide their own instance of a Guzzle client to the Stuart client instance.

This is useful when you need to attach middlewares to the Guzzle client (ie, for logging purposes).