### PR TITLE
Force reading of full response body

### DIFF
--- a/src/Stuart/Infrastructure/ApiResponseFactory.php
+++ b/src/Stuart/Infrastructure/ApiResponseFactory.php
@@ -7,7 +7,7 @@ class ApiResponseFactory
     public static function fromGuzzleHttpResponse($guzzleHttpResponse)
     {
         $statusCode = $guzzleHttpResponse->getStatusCode();
-        $body = $guzzleHttpResponse->getBody()->getContents();
+        $body = (string) $guzzleHttpResponse->getBody();
         return new ApiResponse($statusCode, $body);
     }
 }


### PR DESCRIPTION
This prevents getting invalid/empty responses when some
middlewares read the response stream but do not rewind the
response body stream after usage