### PR TITLE
Fix warning when transport_type is not available in JSON response

### DIFF
--- a/src/Stuart/Converters/JsonToJob.php
+++ b/src/Stuart/Converters/JsonToJob.php
@@ -20,7 +20,7 @@ class JsonToJob
         $job = new Job();
 
         $job->setId($body->id);
-        $job->setTransportType($body->transport_type !== null ? $body->transport_type : null);
+        $job->setTransportType(isset($body->transport_type) ? $body->transport_type : null);
         $job->setStatus($body->status);
 
         foreach ($body->deliveries as $delivery) {


### PR DESCRIPTION
isset(...) will return true only if: the property is defined on an object (or the key exists in an array) and its value is not null