### PR TITLE
changed private to protected for methods in authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 3.7.0
+1. Moved `private` methods to `protected` in `Authenticator` class to enabled better extending.
+
 ####3.6.3
 1. Fixes typo in sandbox API url
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#### 3.7.0
+#### 3.6.4
 1. Moved `private` methods to `protected` in `Authenticator` class to enabled better extending.
 
 ####3.6.3

--- a/src/Stuart/Infrastructure/Authenticator.php
+++ b/src/Stuart/Infrastructure/Authenticator.php
@@ -55,12 +55,12 @@ class Authenticator
         return $this->cache !== null;
     }
 
-    private function getAccessTokenFromCache()
+    protected function getAccessTokenFromCache()
     {
         return $this->cache->get($this->accessTokenCacheKey());
     }
 
-    private function accessTokenCacheKey()
+    protected function accessTokenCacheKey()
     {
         $envAsString = $this->environment === Environment::SANDBOX ? 'SANDBOX' : 'PRODUCTION';
         return 'STUART_' . $envAsString . '_CACHE_ACCESS_TOKEN_KEY';
@@ -75,7 +75,7 @@ class Authenticator
         return $accessToken;
     }
 
-    private function addAccessTokenToCache($accessToken)
+    protected function addAccessTokenToCache($accessToken)
     {
         $this->cache->set($this->accessTokenCacheKey(), $accessToken);
     }

--- a/src/Stuart/Infrastructure/HttpClient.php
+++ b/src/Stuart/Infrastructure/HttpClient.php
@@ -76,7 +76,7 @@ class HttpClient
     {
         return [
             'Authorization' => 'Bearer ' . $this->authenticator->getAccessToken(),
-            'User-Agent' => 'stuart-php-client/3.6.3',
+            'User-Agent' => 'stuart-php-client/3.6.4',
             'Content-Type' => 'application/json'
         ];
     }

--- a/tests/Stuart/tests/Infrastructure/HttpClientTest.php
+++ b/tests/Stuart/tests/Infrastructure/HttpClientTest.php
@@ -13,7 +13,7 @@ use Stuart\Infrastructure\HttpClient;
 
 class HttpClientTest extends \PHPUnit\Framework\TestCase
 {
-    const PHP_CLIENT_USER_AGENT = 'stuart-php-client/3.6.3';
+    const PHP_CLIENT_USER_AGENT = 'stuart-php-client/3.6.4';
     private $authenticator;
     private $container;
 


### PR DESCRIPTION
as it says in the title, this should make extension a little easier here

our use case is having multiple Stuart accounts on one marketplace, the current implementation would have overwritten auth tokens every time a different account was used by the server

at current we've had to make a complete copy of the class due to the `private` methods, making them `protected` would mean we can use your bundle and not worry about breaking changes when the `Authenticator` class is changed

not sure who to tag or which branch to target on this, is it you @maximilientyc (you've got the most activity here)